### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           hugo-version: 'latest'
           extended: true
+      - name: Fetch theme
+        run: git clone --depth 1 https://github.com/alex-shpak/hugo-book.git site/themes/hugo-book
       - name: Build
         run: hugo --minify -s site
       - name: Deploy

--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ This repository contains a Hugo site based on the **Book** theme. It gathers all
 ## Local development
 
 1. Install [Hugo](https://gohugo.io/) with extended support.
-2. Fetch the Book theme:
+2. Fetch the Book theme (once):
 
 ```bash
-git submodule add https://github.com/alex-shpak/hugo-book.git site/themes/hugo-book
+git clone --depth 1 https://github.com/alex-shpak/hugo-book.git site/themes/hugo-book
 ```
+
+The CI workflow automatically clones the theme during deployment, so you only
+need to run the command above when developing locally.
 
 3. Build the site locally:
 


### PR DESCRIPTION
## Summary
- fix failing deploy by downloading hugo-book theme in CI
- update README instructions for obtaining the theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6843f5d84978832cb3614addec576c8d