### PR TITLE
Update GH Pages workflow permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,6 +3,8 @@ name: Deploy Hugo site to GitHub Pages
 on:
   push:
     branches: [ main ]
+permissions:
+  contents: write
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- allow GitHub Pages deployment to write to `contents`

## Testing
- `make test` *(fails: No rule to make target `test`)*
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_6843f95ef334832cafb9476ee52f1e06